### PR TITLE
Support alternative coordinate reference systems in .wld files

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,10 @@ use `--wld` option. You can convert png+wld to geotiff with GDAL:
 
     gdal_translate -of GTiff -a_srs epsg:4326 image.png image.tif
 
+The OziExplorer georefencing files exported by Nik4 currently only support EPSG:3857 (the coordinate reference system used by most slippy maps including [OpenStreetMap Carto](https://github.com/gravitystorm/openstreetmap-carto) and Google Maps). For most people, this won't be an issue.
+
+The `.wld` files exported by Nik4 support alternative coordinate reference systems such as EPSG:27700 (British National Grid). Nik4 will automatically use the SRS specified in your Mapnik XML stylesheet and the coordinates contained in the `.wld` file will match this. However, `.wld` files do not contain any information about the coordinate reference system that has been used so when importing the file into other software such as QGIS, you will need to specify this.
+
 ### Make a BIG raster image
 
 You would likely encounter out of memory error while trying to generate 16311×10709 image from the last


### PR DESCRIPTION
Hi and thanks very much for taking the time to create this useful script.

A bit of background... In Great Britain, Ordnance Survey maps (used by many hikers etc.) use the British National Grid (EPSG:27700). This system is widely used to specify co-ordinates and so it is useful to be able to use this coordinate reference system in Mapnik.

I have modified Nik4 to grab the SRS from the Mapnik XML stylesheet so that the `.wld` file contains the correct coordinates when using alternative coordinate reference systems such as the British National Grid. I've tested this with EPSG:3857 and EPSG:27700 maps by importing into QGIS and it appears to work. (If you save the world file with extension `.pngw` it is automatically used by QGIS when opening the PNG image.)

Unfortunately exporting the relevant parameters for the SRS specified in the Mapnik stylesheet to an OziExplorer file (as I suggested in #25) is a bit much for me to get my head around, although [this site](http://www.oziexplorer3.com/eng/help/map_file_format.html) explains the file format.
