### PR TITLE
Mapnik Python bindings expect 8-bit strings, not unicode

### DIFF
--- a/nik4.py
+++ b/nik4.py
@@ -392,7 +392,7 @@ def run(options):
 
     # for layer processing we need to create the Map object
     m = mapnik.Map(100, 100)  # temporary size, will be changed before output
-    mapnik.load_map_from_string(m, style_xml, False, style_path)
+    mapnik.load_map_from_string(m, style_xml.encode("utf-8"), False, style_path)
     m.srs = proj_target.params()
 
     # register non-standard fonts


### PR DESCRIPTION
This fixes following error:

```
Traceback (most recent call last):
  File "./nik4.py", line 602, in <module>
    run(options)
  File "./nik4.py", line 369, in run
    mapnik.load_map_from_string(m, style_xml, False, style_path)
Boost.Python.ArgumentError: Python argument types in
    mapnik._mapnik.load_map_from_string(Map, unicode, bool, str)
did not match C++ signature:
    load_map_from_string(mapnik::Map {lvalue}, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >)
    load_map_from_string(mapnik::Map {lvalue}, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, bool)
    load_map_from_string(mapnik::Map {lvalue}, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, bool, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >)
```

This error was introduced by commit 0125bf703f61b756c5f3f68b953650fb22bc4492.