### PR TITLE
Fix --fonts CLI option

### DIFF
--- a/nik4.py
+++ b/nik4.py
@@ -286,6 +286,11 @@ def run(options):
     bbox = None
     rotate = not options.norotate
 
+    # register non-standard fonts
+    if options.fonts:
+        for f in options.fonts:
+            add_fonts(f)
+
     if (options.ozi and options.projection.lower() != 'epsg:3857'
             and options.projection != EPSG_3857):
         raise Exception('Ozi map file output is only supported for Web Mercator (EPSG:3857). ' +
@@ -420,11 +425,6 @@ def run(options):
     m = mapnik.Map(100, 100)  # temporary size, will be changed before output
     mapnik.load_map_from_string(m, style_xml.encode("utf-8"), False, style_path)
     m.srs = proj_target.params()
-
-    # register non-standard fonts
-    if options.fonts:
-        for f in options.fonts:
-            add_fonts(f)
 
     # get bbox from layer extents
     if options.fit:


### PR DESCRIPTION
This option was introduced many years ago and has since bit-rotted.
I don't have fonts installed globally on my system, so I need to use the `--fonts` option.
But without this commit, I get the following error when trying to use the `--fonts` option:
```
Traceback (most recent call last):
  File "/path/to/nik4.py", line 677, in <module>
    run(options)
  File "/path/to/nik4.py", line 422, in run
    mapnik.load_map_from_string(m, style_xml.encode("utf-8"), False, style_path)
RuntimeError: no valid fonts could be loaded in FontSet 'fontset-0' in FontSet at line 15
```
To fix this, load the fonts earlier. The exact place where we load them is not important, as long as it is above all calls to mapnik functions, which require fonts to be loaded (`mapnik.load_map_from_string()` currently). To be on the safe side regarding future modifications, I moved the code snippet pretty much to the top of the function, which results in this option working again.