### PR TITLE
Bugfix: Make regex work with positive lat/lon degrees

### DIFF
--- a/nik4.py
+++ b/nik4.py
@@ -168,10 +168,10 @@ def parse_url(url, options):
         lat = float(m.group(2))
         lon = float(m.group(3))
     else:
-        m = re.search(r'lat=(-[0-9]{1,2}\.[0-9]+)', url, flags=re.IGNORECASE)
+        m = re.search(r'lat=(-?[0-9]{1,2}\.[0-9]+)', url, flags=re.IGNORECASE)
         if m:
             lat = float(m.group(1))
-        m = re.search(r'lon=(-[0-9]{1,3}\.[0-9]+)', url, flags=re.IGNORECASE)
+        m = re.search(r'lon=(-?[0-9]{1,3}\.[0-9]+)', url, flags=re.IGNORECASE)
         if m:
             lon = float(m.group(1))
         m = re.search(r'zoom=([0-9]{1,2})', url, flags=re.IGNORECASE)


### PR DESCRIPTION
Found by adding tests covering that in https://github.com/Nakaner/Nik4/commit/d895725b40bdacab51b5765aa5d0cf0301e70b32 as part of porting Nik4 to C++.